### PR TITLE
Save Firebase credentials as build artifacts and fix CI caching

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -20,3 +20,4 @@ runs:
           **/*.apk
           **/build
           **/secrets.properties
+          **/google-services.json

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -4,8 +4,6 @@ runs:
   steps:
     - name: Set up Gradle
       uses: ./.github/actions/setup-gradle
-      with:
-        cache-key: build-android
     - name: Build Android
       shell: bash
       run: |

--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -28,3 +28,4 @@ runs:
           ~/Library/Developer/Xcode/DerivedData/**/*.app.dSYM
           **/build
           **/secrets.properties
+          **/GoogleService-Info.plist

--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -4,12 +4,8 @@ runs:
   steps:
     - name: Set up Gradle
       uses: ./.github/actions/setup-gradle
-      with:
-        cache-key: build-ios
     - name: Set up Xcode
       uses: ./.github/actions/setup-xcode
-      with:
-        cache-key: build-ios
     - name: Build iOS
       shell: bash
       run: |

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,7 +1,4 @@
 name: 'setup-gradle'
-inputs:
-  cache-key:
-    required: true
 runs:
   using: "composite"
   steps:
@@ -16,7 +13,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: '~/.konan/**'
-        key: ${{ inputs.cache-key }}-konan
+        key: ${{ github.job }}-konan
     - name: Set up secrets
       shell: bash
       run: |

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -13,6 +13,6 @@ runs:
     - name: Set up Xcode
       uses: irgaly/xcode-cache@v1
       with:
-        key: xcode-cache-derived-data-${{ inputs.cache-key }}-${{ github.workflow }}-${{ github.sha }}
-        restore-keys: xcode-cache-derived-data-${{ inputs.cache-key }}-${{ github.workflow }}
-        swiftpm-cache-key: swiftpm-cache-key-${{ inputs.cache-key }}-${{ hashFiles( '**/Package.resolved' ) }}
+        key: xcode-cache-derived-data-${{ github.job }}-${{ github.workflow }}-${{ github.sha }}
+        restore-keys: xcode-cache-derived-data-${{ github.job }}-${{ github.workflow }}
+        swiftpm-cache-key: swiftpm-cache-key-${{ github.job }}-${{ hashFiles( '**/Package.resolved' ) }}

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -13,5 +13,6 @@ runs:
     - name: Set up Xcode
       uses: irgaly/xcode-cache@v1
       with:
-        key: ${{ inputs.cache-key }}-${{ github.workflow }}-${{ github.sha }}
-        restore-keys: ${{ inputs.cache-key }}-${{ github.workflow }}-
+        key: xcode-cache-derived-data-${{ inputs.cache-key }}-${{ github.workflow }}-${{ github.sha }}
+        restore-keys: xcode-cache-derived-data-${{ inputs.cache-key }}-${{ github.workflow }}
+        swiftpm-cache-key: swiftpm-cache-key-${{ inputs.cache-key }}-${{ hashFiles( {swiftpm-package-resolved-file} ) }}

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -1,7 +1,4 @@
 name: 'setup-xcode'
-inputs:
-  cache-key:
-    required: true
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -15,4 +15,4 @@ runs:
       with:
         key: xcode-cache-derived-data-${{ inputs.cache-key }}-${{ github.workflow }}-${{ github.sha }}
         restore-keys: xcode-cache-derived-data-${{ inputs.cache-key }}-${{ github.workflow }}
-        swiftpm-cache-key: swiftpm-cache-key-${{ inputs.cache-key }}-${{ hashFiles( {swiftpm-package-resolved-file} ) }}
+        swiftpm-cache-key: swiftpm-cache-key-${{ inputs.cache-key }}-${{ hashFiles( '**/Package.resolved' ) }}

--- a/.github/actions/test-android/action.yml
+++ b/.github/actions/test-android/action.yml
@@ -27,7 +27,7 @@ runs:
       with:
         api-level: 31
         arch: x86_64
-        disk-size: 2048M
+        disk-size: 4G
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
@@ -37,7 +37,7 @@ runs:
       with:
         api-level: 31
         arch: x86_64
-        disk-size: 2048M
+        disk-size: 4G
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true

--- a/.github/actions/test-android/action.yml
+++ b/.github/actions/test-android/action.yml
@@ -11,36 +11,13 @@ runs:
         sudo udevadm trigger --name-match=kvm
     - name: Set up Gradle
       uses: ./.github/actions/setup-gradle
-      with:
-        cache-key: test-android
-    - name: Set up AVD
-      uses: actions/cache@v4
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: avd-31-4g
-    - name: Generate AVD cache snapshot
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 31
-        arch: x86_64
-        disk-size: 4G
-        emulator-boot-timeout: 120
-        force-avd-creation: false
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        disable-animations: false
-        script: echo "Generated AVD cache snapshot"
     - name: Android tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 31
         arch: x86_64
-        disk-size: 4G
+        disk-size: 6G
         emulator-boot-timeout: 120
-        force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: ./gradlew connectedAndroidTest

--- a/.github/actions/test-android/action.yml
+++ b/.github/actions/test-android/action.yml
@@ -20,7 +20,7 @@ runs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key: avd-31
+        key: avd-31-4g
     - name: Generate AVD cache snapshot
       if: steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2
@@ -28,6 +28,7 @@ runs:
         api-level: 31
         arch: x86_64
         disk-size: 4G
+        emulator-boot-timeout: 120
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
@@ -38,6 +39,7 @@ runs:
         api-level: 31
         arch: x86_64
         disk-size: 4G
+        emulator-boot-timeout: 120
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true

--- a/.github/actions/test-android/action.yml
+++ b/.github/actions/test-android/action.yml
@@ -27,6 +27,7 @@ runs:
       with:
         api-level: 31
         arch: x86_64
+        disk-size: 2048M
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
@@ -36,6 +37,7 @@ runs:
       with:
         api-level: 31
         arch: x86_64
+        disk-size: 2048M
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true

--- a/.github/actions/test-ios/action.yml
+++ b/.github/actions/test-ios/action.yml
@@ -4,12 +4,8 @@ runs:
   steps:
     - name: Set up Gradle
       uses: ./.github/actions/setup-gradle
-      with:
-        cache-key: test-ios
     - name: Set up Xcode
       uses: ./.github/actions/setup-xcode
-      with:
-        cache-key: test-ios
     - name: Test iOS
       shell: bash
       run: |

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -4,8 +4,6 @@ runs:
   steps:
     - name: Set up Gradle
       uses: ./.github/actions/setup-gradle
-      with:
-        cache-key: unit-test
     - name: Test
       shell: bash
       run: |


### PR DESCRIPTION
## What does this pull request change?

This PR:
- saves the Firebase credentials as artifacts
- removes AVD caching for Android and just starts a new emulator for the tests
- fixes iOS CI caching errors

## How is this change tested?

Manually

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
